### PR TITLE
Export device enum

### DIFF
--- a/lib/test_widgets_with_size.dart
+++ b/lib/test_widgets_with_size.dart
@@ -1,3 +1,4 @@
 library test_widgets_with_size;
 
 export 'src/test_widgets_with_size.dart';
+export 'src/device.dart';


### PR DESCRIPTION
To use the DeviceWidget we need to use this enum, so, because of that, we need to expose this for the application.